### PR TITLE
ci: rename to ci.yml and add lint-and-test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         pylint $(git ls-files '*.py')
 
   lint-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [build]
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,17 @@ jobs:
       run: |
         pylint $(git ls-files '*.py')
 
+  markdown:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v23
+
   lint-and-test:
     runs-on: ubuntu-slim
-    needs: [build]
+    needs: [build, markdown]
     if: always()
     steps:
       - name: Verify required jobs succeeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
-name: Pylint
+name: CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -27,3 +29,14 @@ jobs:
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')
+
+  lint-and-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: always()
+    steps:
+      - name: Verify required jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs did not succeed."
+          exit 1

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,22 @@
+{
+  "globs": ["**/*.md"],
+  "gitignore": true,
+  "ignores": ["node_modules/**"],
+  "config": {
+    "default": true,
+    "MD003": { "style": "atx" },
+    "MD004": { "style": "dash" },
+    "MD007": { "indent": 2 },
+    "MD013": false, // allow long lines
+    "MD024": { "siblings_only": true },
+    "MD028": false, // allow separation between quote blocks
+    "MD033": {
+      "allowed_elements": ["details", "summary", "br", "sub", "sup", "kbd", "abbr", "a", "img"]
+    },
+    "MD041": false,
+    "MD046": { "style": "fenced" },
+    "MD048": { "style": "backtick" },
+    "MD055": { "style": "leading_and_trailing" },
+    "MD060": { "style": "compact", "aligned_delimiter": false }
+  }
+}


### PR DESCRIPTION
Renames `lint-code.yml` → `ci.yml`, adds a `pull_request` trigger (a required check must run on PRs, but the workflow was `on: [push]` only), and adds a `lint-and-test` aggregator job that `needs: [build]`. The pylint job is a matrix (3.8/3.10/3.12), which only produces per-version check contexts like `lint-and-test (3.8)`; the aggregator yields a single bare `lint-and-test` context that the org ruleset requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)